### PR TITLE
Include Laravel 5.5 in Laravel53Worker implementation

### DIFF
--- a/src/Integrations/BindsWorker.php
+++ b/src/Integrations/BindsWorker.php
@@ -16,7 +16,7 @@ trait BindsWorker
      * @var array
      */
     protected $workerImplementations = [
-        '5\.[34].*' => Laravel53Worker::class
+        '5\.[345].*' => Laravel53Worker::class
     ];
 
     /**


### PR DESCRIPTION
Hey 👋 

Currently the `Laravel53Worker` is not targeted for Laravel 5.5. This causes Laravel 5.5 installs to fallback to `DefaultWorker` which does not use `WorkerOptions` and thus throws a type error.

This PR simply updates the regex in `BindsWorker` to target Laravel 5.5.