### PR TITLE
Modified the LumenServiceProvider to use Lumen 5.5 router instance

### DIFF
--- a/src/Integrations/LumenServiceProvider.php
+++ b/src/Integrations/LumenServiceProvider.php
@@ -32,8 +32,8 @@ class LumenServiceProvider extends ServiceProvider
      */
     protected function addRoutes()
     {
-        $this->app->post('/worker/schedule', 'Dusterio\AwsWorker\Controllers\WorkerController@schedule');
-        $this->app->post('/worker/queue', 'Dusterio\AwsWorker\Controllers\WorkerController@queue');
+        $this->app->router->post('/worker/schedule', 'Dusterio\AwsWorker\Controllers\WorkerController@schedule');
+        $this->app->router->post('/worker/queue', 'Dusterio\AwsWorker\Controllers\WorkerController@queue');
     }
 
     /**


### PR DESCRIPTION
Lumen 5.5 had to update it's bootstrap file and now uses a Router instance to create routes:

https://lumen.laravel.com/docs/5.5/upgrade#upgrade-5.5.0

This updates the `addRoutes` method to use the `$app->router`