### PR TITLE
Laravel 5.6 support

### DIFF
--- a/src/Integrations/BindsWorker.php
+++ b/src/Integrations/BindsWorker.php
@@ -16,7 +16,7 @@ trait BindsWorker
      * @var array
      */
     protected $workerImplementations = [
-        '5\.[345].*' => Laravel53Worker::class
+        '5\.[3456].*' => Laravel53Worker::class
     ];
 
     /**


### PR DESCRIPTION
Adds 5.6 support to avoid 500 type error (as detailed here #23) and resolves #29 