### PR TITLE
Removed use of env function to support cached environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Or add it to `composer.json` manually:
 ];
 ```
 
+Then publish the package in order to create the config file.
+
+```sh
+php artisan vendor:publish --provider="Dusterio\AwsWorker\Integrations\LaravelServiceProvider"
+```
+
 After adding service provider, you should be able to see two special routes that we added:
 
 ```bash
@@ -152,6 +158,12 @@ So that's it - if you (or AWS) hits ```/worker/queue```, Laravel will process on
 ```php
 // Add in your bootstrap/app.php
 $app->register(Dusterio\AwsWorker\Integrations\LumenServiceProvider::class);
+```
+
+Then publish the package in order to create the config file.
+
+```sh
+php artisan vendor:publish --provider="Dusterio\AwsWorker\Integrations\LumenServiceProvider"
 ```
 
 ## Errors and exceptions

--- a/assets/config/aws-worker.php
+++ b/assets/config/aws-worker.php
@@ -14,5 +14,5 @@ return [
       |
       | Defines whether to register worker routes or not.
      */
-    'register_worker_routes' => function_exists('env') && !env('REGISTER_WORKER_ROUTES', true)
+    'register_worker_routes' => function_exists('env') && !!env('REGISTER_WORKER_ROUTES', true)
 ];

--- a/assets/config/aws-worker.php
+++ b/assets/config/aws-worker.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @author      José Lorente <jose.lorente.martin@gmail.com>
+ * @license     The MIT License (MIT)
+ * @copyright   José Lorente
+ * @version     1.0
+ */
+return [
+    /*
+      |--------------------------------------------------------------------------
+      | Register worker routes
+      |--------------------------------------------------------------------------
+      |
+      | Defines whether to register worker routes or not.
+     */
+    'register_worker_routes' => function_exists('env') && !env('REGISTER_WORKER_ROUTES', true)
+];

--- a/src/Integrations/LaravelServiceProvider.php
+++ b/src/Integrations/LaravelServiceProvider.php
@@ -17,14 +17,15 @@ use Illuminate\Queue\QueueManager;
  */
 class LaravelServiceProvider extends ServiceProvider
 {
-    use BindsWorker;
+    use BindsWorker,
+        RegistersConfig;
 
     /**
      * @return void
      */
     public function register()
     {
-        if (function_exists('env') && ! env('REGISTER_WORKER_ROUTES', true)) return;
+        if (!config('aws-worker.register_worker_routes')) return;
 
         $this->bindWorker();
         $this->addRoutes();
@@ -44,6 +45,10 @@ class LaravelServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->app->runningInConsole()) {
+            $this->registerConfig();
+        }
+        
         $this->app->singleton(QueueManager::class, function() {
             return new QueueManager($this->app);
         });

--- a/src/Integrations/LumenServiceProvider.php
+++ b/src/Integrations/LumenServiceProvider.php
@@ -14,14 +14,15 @@ use Illuminate\Queue\QueueManager;
  */
 class LumenServiceProvider extends ServiceProvider
 {
-    use BindsWorker;
+    use BindsWorker,
+        RegistersConfig;
 
     /**
      * @return void
      */
     public function register()
     {
-        if (function_exists('env') && ! env('REGISTER_WORKER_ROUTES', true)) return;
+        if (!config('aws-worker.register_worker_routes')) return;
 
         $this->bindWorker();
         $this->addRoutes(preg_match('/5\.5\..*/', $this->app->version()) ? $this->app->router : $this->app);
@@ -42,6 +43,10 @@ class LumenServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->app->runningInConsole()) {
+            $this->registerConfig();
+        }
+        
         $this->app->singleton(QueueManager::class, function() {
             return new QueueManager($this->app);
         });

--- a/src/Integrations/RegistersConfig.php
+++ b/src/Integrations/RegistersConfig.php
@@ -15,7 +15,7 @@ trait RegistersConfig
     protected function registerConfig()
     {
         $this->publishes([
-            __DIR__ . '/../assets/config/aws-worker.php' => config_path('aws-worker.php'),
+            __DIR__ . '/../../assets/config/aws-worker.php' => config_path('aws-worker.php'),
                 ], 'aws-worker');
     }
 

--- a/src/Integrations/RegistersConfig.php
+++ b/src/Integrations/RegistersConfig.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Dusterio\AwsWorker\Integrations;
+
+/**
+ * Trait RegistersConfig
+ * @package Dusterio\AwsWorker\Integrations
+ */
+trait RegistersConfig
+{
+
+    /**
+     * Registers the config file for the package.
+     */
+    protected function registerConfig()
+    {
+        $this->publishes([
+            __DIR__ . '/../assets/config/aws-worker.php' => config_path('aws-worker.php'),
+                ], 'aws-worker');
+    }
+
+}


### PR DESCRIPTION
This Pull Request removes the use of the env() function to obtain the value of the "REGISTER_WORKER_ROUTES" environment variable. 

Is related to the [this issue](https://github.com/dusterio/laravel-aws-worker/issues/33).

This pull request breaks compatibility with previous versions. Users who want to install a new version with this code will have to publish the package in order to make it work as it has been working until now.