### PR TITLE
Resolve Lumen error about $isDownForMaintenance

### DIFF
--- a/src/Integrations/LumenServiceProvider.php
+++ b/src/Integrations/LumenServiceProvider.php
@@ -47,7 +47,7 @@ class LumenServiceProvider extends ServiceProvider
         });
 
         // If lumen version is 6 or above then the worker bindings change. So we initiate it here
-        if ($this->app->version() >= 6) {
+        if (preg_match('/Lumen \(6/', $this->app->version())) {
             $this->app->singleton(Worker::class, function () {
                 $isDownForMaintenance = function () {
                     return $this->app->isDownForMaintenance();

--- a/src/Integrations/LumenServiceProvider.php
+++ b/src/Integrations/LumenServiceProvider.php
@@ -7,6 +7,8 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\QueueManager;
+use Illuminate\Queue\Worker;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 
 /**
  * Class CustomQueueServiceProvider


### PR DESCRIPTION
With the Laravel 6.0 migration in 540c8611456f0dc61d5f4659d1cec32e1cd5ef3e, two additional use statements were added to the Laravel provider but not the Lumen provider, introducing the following error when running under Lumen 6:

Unresolvable dependency resolving [Parameter #3 [ <required> callable $isDownForMaintenance ]] in class Illuminate\Queue\Worker