### PR TITLE
Update BindsWorker.php to use Laravel8Worker for Laravel 9.

### DIFF
--- a/src/Integrations/BindsWorker.php
+++ b/src/Integrations/BindsWorker.php
@@ -22,7 +22,7 @@ trait BindsWorker
     protected $workerImplementations = [
         '5\.[345678]\.\d+' => Laravel53Worker::class,
         '[67]\.\d+\.\d+' => Laravel6Worker::class,
-        '[8]\.\d+\.\d+' => Laravel8Worker::class
+        '[89]\.\d+\.\d+' => Laravel8Worker::class
     ];
 
     /**


### PR DESCRIPTION
To support Laravel 9, you need to use the Laravel8Worker (or create a L9 worker?).

This change updates $workerImplementations to include versions 8 OR 9.