### PR TITLE
Feature/laravel 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "illuminate/support": "5.*|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/queue": "5.*|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/bus": "5.*|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/queue": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/bus": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0",
         "aws/aws-sdk-php": "~3.0",
-        "illuminate/http": "5.*|^6.0|^7.0|^8.0|^9.0"
+        "illuminate/http": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*|^9.5.10",

--- a/src/Integrations/BindsWorker.php
+++ b/src/Integrations/BindsWorker.php
@@ -22,7 +22,7 @@ trait BindsWorker
     protected $workerImplementations = [
         '5\.[345678]\.\d+' => Laravel53Worker::class,
         '[67]\.\d+\.\d+' => Laravel6Worker::class,
-        '[89]\.\d+\.\d+' => Laravel8Worker::class
+        '([89]|10)\.\d+\.\d+' => Laravel8Worker::class
     ];
 
     /**

--- a/src/Integrations/BindsWorker.php
+++ b/src/Integrations/BindsWorker.php
@@ -44,7 +44,7 @@ trait BindsWorker
     protected function bindWorker()
     {
         // If Laravel version is 6 or above then the worker bindings change. So we initiate it here
-        if ($this->app->version() >= 6) {
+        if ((int) $this->app->version() >= 6) {
             $this->app->singleton(Worker::class, function () {
                 $isDownForMaintenance = function () {
                     return $this->app->isDownForMaintenance();


### PR DESCRIPTION
Adding fixes discovered from using laravel shift compatibility version.

\Dusterio\AwsWorker\Integrations\BindsWorker
- Update regex so Laravel8Worker class is used for laravel 10
- Fix issue with comparing a string to an integer meaning that "10.0.0" >= 6 would return false. Fixed by converting "10.0.0" into just 10 with an int cast