### PR TITLE
Laravel 11 support fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,12 @@
         "psr-4": {
             "Dusterio\\AwsWorker\\": "src/"
         }
-    }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Dusterio\AwsWorker\Integrations\LaravelServiceProvider"
+            ]
+        }
+    },
 }

--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,5 @@
         "psr-4": {
             "Dusterio\\AwsWorker\\": "src/"
         }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Dusterio\\AwsWorker\\Integrations\\LaravelServiceProvider"
-            ]
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,12 @@
         "psr-4": {
             "Dusterio\\AwsWorker\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Dusterio\\AwsWorker\\Integrations\\LaravelServiceProvider"
+            ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,5 @@
                 "Dusterio\\AwsWorker\\Integrations\\LaravelServiceProvider"
             ]
         }
-    },
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Dusterio\AwsWorker\Integrations\LaravelServiceProvider"
+                "Dusterio\\AwsWorker\\Integrations\\LaravelServiceProvider"
             ]
         }
     },

--- a/src/Controllers/WorkerController.php
+++ b/src/Controllers/WorkerController.php
@@ -42,6 +42,8 @@ class WorkerController extends LaravelController
         $command = $request->headers->get('X-Aws-Sqsd-Taskname', $this::LARAVEL_SCHEDULE_COMMAND);
         if ($command != $this::LARAVEL_SCHEDULE_COMMAND) return $this->runSpecificCommand($kernel, $request->headers->get('X-Aws-Sqsd-Taskname'));
 
+        $kernel->bootstrap();
+        
         $events = $schedule->dueEvents($laravel);
         $eventsRan = 0;
         $messages = [];

--- a/src/Integrations/BindsWorker.php
+++ b/src/Integrations/BindsWorker.php
@@ -22,7 +22,7 @@ trait BindsWorker
     protected $workerImplementations = [
         '5\.[345678]\.\d+' => Laravel53Worker::class,
         '[67]\.\d+\.\d+' => Laravel6Worker::class,
-        '([89]|10)\.\d+\.\d+' => Laravel8Worker::class
+        '([89]|10|11)\.\d+\.\d+' => Laravel8Worker::class
     ];
 
     /**


### PR DESCRIPTION
When using Laravel 11 with this package, neither schedule or queue works. This should fix it.


- Manually bootstrap kernel to detect jobs defined in console.php route file. In the case of `$this->runSpecificCommand` the kernel is bootstrapped by the call to `$kernel->call()`.
- Autoload service provider
- Bind Laravel8Worker