### PR TITLE
Fix to detect jobs in routes/console.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,12 @@
         "psr-4": {
             "Dusterio\\AwsWorker\\": "src/"
         }
-    }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Dusterio\AwsWorker\Integrations\LaravelServiceProvider"
+            ]
+        }
+    },
 }

--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,5 @@
         "psr-4": {
             "Dusterio\\AwsWorker\\": "src/"
         }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Dusterio\\AwsWorker\\Integrations\\LaravelServiceProvider"
-            ]
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,12 @@
         "psr-4": {
             "Dusterio\\AwsWorker\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Dusterio\\AwsWorker\\Integrations\\LaravelServiceProvider"
+            ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,5 @@
                 "Dusterio\\AwsWorker\\Integrations\\LaravelServiceProvider"
             ]
         }
-    },
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Dusterio\AwsWorker\Integrations\LaravelServiceProvider"
+                "Dusterio\\AwsWorker\\Integrations\\LaravelServiceProvider"
             ]
         }
     },

--- a/src/Controllers/WorkerController.php
+++ b/src/Controllers/WorkerController.php
@@ -42,6 +42,8 @@ class WorkerController extends LaravelController
         $command = $request->headers->get('X-Aws-Sqsd-Taskname', $this::LARAVEL_SCHEDULE_COMMAND);
         if ($command != $this::LARAVEL_SCHEDULE_COMMAND) return $this->runSpecificCommand($kernel, $request->headers->get('X-Aws-Sqsd-Taskname'));
 
+        $kernel->bootstrap();
+        
         $events = $schedule->dueEvents($laravel);
         $eventsRan = 0;
         $messages = [];

--- a/src/Integrations/BindsWorker.php
+++ b/src/Integrations/BindsWorker.php
@@ -22,7 +22,7 @@ trait BindsWorker
     protected $workerImplementations = [
         '5\.[345678]\.\d+' => Laravel53Worker::class,
         '[67]\.\d+\.\d+' => Laravel6Worker::class,
-        '([89]|10)\.\d+\.\d+' => Laravel8Worker::class
+        '([89]|10|11)\.\d+\.\d+' => Laravel8Worker::class
     ];
 
     /**


### PR DESCRIPTION
#100 

Manually bootstrap kernel to detect jobs defined in console.php route file. In the case of $this->runSpecificCommand the kernel is bootstrapped by the call to $kernel->call().

We call `$kernel->bootstrap` because we need to run `discoverCommands` below (Console/Kernel). Since the application is already bootstrapped with the HTTP kernel only the command discovery and `loadDeferredProviders` will be called in reality.

Console\Kernel
```
    /**
     * Bootstrap the application for artisan commands.
     *
     * @return void
     */
    public function bootstrap()
    {
        if (! $this->app->hasBeenBootstrapped()) {
            $this->app->bootstrapWith($this->bootstrappers());
        }

        $this->app->loadDeferredProviders();

        if (! $this->commandsLoaded) {
            $this->commands();

            if ($this->shouldDiscoverCommands()) {
                $this->discoverCommands();
            }

            $this->commandsLoaded = true;
        }
    }
   ```
    
The console commands are resolved in ApplicationBuilder and passed to the Kernel:
 
```
        /**
     * Register additional Artisan commands with the application.
     *
     * @param  array  $commands
     * @return $this
     */
    public function withCommands(array $commands = [])
    {
        if (empty($commands)) {
            $commands = [$this->app->path('Console/Commands')];
        }

        $this->app->afterResolving(ConsoleKernel::class, function ($kernel) use ($commands) {
            [$commands, $paths] = collect($commands)->partition(fn ($command) => class_exists($command));
            [$routes, $paths] = $paths->partition(fn ($path) => is_file($path));

            $kernel->addCommands($commands->all());
            $kernel->addCommandPaths($paths->all());
            $kernel->addCommandRoutePaths($routes->all());
        });

        return $this;
    }
```
   
    
    