### PR TITLE
Fix: Add Laravel 12 Support

### DIFF
--- a/src/Integrations/BindsWorker.php
+++ b/src/Integrations/BindsWorker.php
@@ -22,7 +22,7 @@ trait BindsWorker
     protected $workerImplementations = [
         '5\.[345678]\.\d+' => Laravel53Worker::class,
         '[67]\.\d+\.\d+' => Laravel6Worker::class,
-        '([89]|10|11)\.\d+\.\d+' => Laravel8Worker::class
+        '([89]|10|11|12)\.\d+\.\d+' => Laravel8Worker::class
     ];
 
     /**

--- a/src/Wrappers/DefaultWorker.php
+++ b/src/Wrappers/DefaultWorker.php
@@ -3,6 +3,8 @@
 namespace Dusterio\AwsWorker\Wrappers;
 
 use Illuminate\Queue\Worker;
+use Illuminate\Queue\WorkerOptions;
+use Illuminate\Contracts\Cache\Repository as Cache;
 
 /**
  * Class DefaultWorker
@@ -11,11 +13,23 @@ use Illuminate\Queue\Worker;
 class DefaultWorker implements WorkerInterface
 {
     /**
+     * @var Worker
+     */
+    public $worker;
+
+    /**
+     * @var Cache
+     */
+    public $cache;
+
+    /**
      * DefaultWorker constructor.
      * @param Worker $worker
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
      */
-    public function __construct(Worker $worker)
+    public function __construct(Worker $worker, Cache $cache)
     {
+        $this->cache = $cache;
         $this->worker = $worker;
     }
 
@@ -27,8 +41,10 @@ class DefaultWorker implements WorkerInterface
      */
     public function process($queue, $job, array $options)
     {
+        $workerOptions = new WorkerOptions('default', $options['delay'], 128, $options['timeout'], 3, $options['maxTries']);
+
         $this->worker->process(
-            $queue, $job, $options['maxTries'], $options['delay']
+            $queue, $job, $workerOptions
         );
     }
 }


### PR DESCRIPTION
This PR ensures full compatibility with Laravel 12.x by:

- Updating the BindsWorker logic to recognize Laravel 12 versions.
- Setting the default worker to Laravel8Worker to support Laravel 12 and future versions when no specific worker binding is defined.


Why?
These changes address a missing piece from the Laravel 12 support update. The package is currently broken on Laravel 12, throwing the following error:
_Illuminate\Queue\Worker::process(): Argument #3 ($options) must be of type Illuminate\Queue\WorkerOptions, int given, called in /var/app/current/vendor/dusterio/laravel-aws-worker/src/Wrappers/DefaultWorker.php on line 30_